### PR TITLE
CSS Patch For Library Pages

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -15,6 +15,19 @@ a {
 a:hover {
     color: #6699CC;
 }
+code {
+    display: inline-block !important;
+    margin: 0 0 6px !important;
+}
+
+table code {
+    max-width: 100% !important;
+    word-wrap: break-word !important;
+}
+
+table.table-bordered td:nth-child(2) {
+    max-width: 190px;
+}
 
 /**
  * Fork Sticker Styles


### PR DESCRIPTION
Tweaked The CSS so that larger namespaces don't cause the table to overflow past the container.

![screen shot 2017-02-21 at 3 54 32 pm](https://cloud.githubusercontent.com/assets/5582018/23190827/1dc93b44-f84f-11e6-8b89-0746d3205d88.png)
![screen shot 2017-02-21 at 3 54 38 pm](https://cloud.githubusercontent.com/assets/5582018/23190828/1de1ceca-f84f-11e6-902c-d71106a7516d.png)
